### PR TITLE
Regional operations SOP v0.1

### DIFF
--- a/regional-ops-sop.md
+++ b/regional-ops-sop.md
@@ -1,0 +1,72 @@
+# OpenClaw Foundation Regional Operations — SOP v0.1
+
+_Lightweight operating rules for regional channels, events, and community presence. Pilot through end of May 2026, then review._
+
+_First implementation: China (Bilibili, WeChat, Weibo, Xiaohongshu). Framework applies to any region._
+
+---
+
+## 1. Account Ownership
+
+All official OpenClaw accounts on regional platforms are Foundation property.
+
+- **Operators** get admin/editor access — sufficient to post, manage content, run events
+- **Access is revocable.** If an operator steps down or becomes unresponsive (14 days no contact), Foundation reassigns access
+- **Registry:** All official accounts are documented in a shared registry — platform, account name, who registered, under what identity, current admin list. The registry is pinned in the regional coordination group and kept current. Operators can register new accounts; the registry ensures the Foundation always knows what exists and who controls it.
+- Accounts are Foundation property regardless of who registered them. Operators acknowledge this when listed in the registry.
+- **Platform constraints:** Some platforms require a local individual or entity for verification (e.g., Chinese platforms require a Chinese ID or business license). Where the Foundation cannot register directly, operators register on behalf of the Foundation. A regional legal entity for formal account ownership is a post-pilot governance item.
+
+## 2. Operator Group
+
+Each region has a coordination group on its primary messaging platform (e.g., WeChat for China, Slack/Discord for others).
+
+**Purpose:** transparency, not approval.
+- Operators post what they're planning (events, content, partnerships) — others can see and comment
+- No one needs permission from the group to act. Notification is the default, not approval.
+- Cross-city coordination (e.g., national campaigns, multi-city events) discussed here before launch
+- Scheduling conflicts: operators resolve directly. If deadlocked, regional Foundation representative decides.
+
+**Entry:** new organizers are added by the regional Foundation representative or an existing operator. The bar is "actively doing work" — organizing events, producing content, running a regional channel. Not a closed club, but someone has to vouch.
+
+## 3. Content & Branding
+
+- Messaging consistent with global OpenClaw positioning
+- Operators translate, localize, and add regional context freely
+- No one speaks "on behalf of OpenClaw Foundation" to press or companies without flagging in the operator group first
+- Social media content: shared content calendar (a shared doc, not a review chain)
+- **Corporate neutrality:** Official channels represent OpenClaw, not any single company. Events are developer-focused, not product showcases for sponsors. Multiple ecosystem partners should be represented — no single company dominates the channel or event lineup. The federation of partners in the room is itself the check.
+- **Political and regulatory sensitivity:** Operators exercise their own judgment on locally sensitive content — they understand their local context better than a US-based Foundation. When in doubt, don't post — pull it back to the group for a second opinion. This is the one area where caution beats speed.
+- **Cross-border awareness:** Some things normal locally may be sensitive for the Foundation (sanctioned entities, unauthorized roadmap commitments, unapproved endorsements), and vice versa. Operators flag anything involving foreign partnerships or official Foundation positioning to their regional Foundation representative.
+
+## 4. Events
+
+Regional operators can:
+- Run local meetups and dev events under OpenClaw branding with notification to operator group
+- Coordinate with ecosystem partners (model labs, cloud providers) directly
+- Escalate to Foundation for anything involving official Foundation-level partnerships or press. Local event sponsorships are handled by operators (see Funding).
+
+Event application flow: see Eco Sessions SOP (forthcoming).
+
+## 5. Funding
+
+Two sources:
+
+1. **Foundation grants.** The Foundation has funds contributed by corporate partners to support community growth. Operators can request funding for events (venue, swag, logistics). Submit a brief cost estimate to the operator group + regional Foundation representative. Approval is lightweight — the goal is to fund community growth, not gatekeep.
+2. **Local sponsorships.** Organizers are free to seek local sponsors for events. Sponsors get acknowledgment at the event, not branding on official Foundation accounts. Sponsorship terms flagged in the operator group for transparency.
+
+Operators who front costs get reimbursed against approved estimates. Don't spend without a prior estimate — the Foundation won't reimburse surprise costs.
+
+## 6. When Things Go Wrong
+
+- Public controversy → operator syncs with Foundation immediately
+- Operator conflict → escalate to regional Foundation representative → Foundation
+- Unresponsive operator → 14 days no contact, Foundation reassigns access after documented outreach attempts
+- Account misuse → access revoked immediately, discussed after
+
+## 7. Pilot Terms
+
+This is v0.1. Pilot runs through **end of May 2026**. Regional Foundation representative calls a review with the operator group to assess what worked, what didn't, and what the longer-term structure should look like. Findings feed into the Foundation's regional governance design.
+
+---
+
+_Extends: OpenClaw Foundation Regional Channel Playbook (v0.1). Adds account ownership registry, operator transparency model, corporate neutrality principle, funding process, and cross-border sensitivity guidance. Designed as global framework; China is first implementation._


### PR DESCRIPTION
## Summary

- Lightweight framework for regional channels, events, and community presence
- Account ownership via shared registry (Foundation property, operators get delegated access)
- Operator coordination groups — transparency, not approval chains
- Corporate neutrality: official channels represent OpenClaw, not any single company
- Funding: Foundation grants + local sponsorships, lightweight approval
- Cross-border and political sensitivity guidance
- Pilot through end of May 2026, then review

Designed as a global framework. China is the first implementation.

Extends the Regional Channel Playbook (v0.1, Dave approved). Adds the governance layer — account ownership, funding process, corporate neutrality principle.

Built on inputs from @Jim_badguy and @AndyML's community operations work — their Regional Channel Playbook and Eco Sessions planning informed the foundation of this SOP.

## Looking for feedback on

- Does the registry model work for account ownership tracking?
- Is the funding process lightweight enough while maintaining transparency?
- Anything missing for your region?