### PR TITLE
Add AI Ecosystem Sessions application playbook

### DIFF
--- a/ai-ecosystem-sessions/application.md
+++ b/ai-ecosystem-sessions/application.md
@@ -1,0 +1,64 @@
+# AI Ecosystem Sessions Playbook (v1)
+
+Purpose: This playbook defines how organizations apply to present at OpenClaw AI Ecosystem Sessions and how applications are evaluated. The process is designed to be open, fair, and efficient.
+
+## How to apply
+
+Open a GitHub issue using the AI Ecosystem Session Application template. Include:
+
+- Organization name and primary contact (must be a co-founder, CEO, or equivalent decision-maker)
+- Session topic and format — what you'll present and what the audience will take away
+- Community value — how this benefits OpenClaw developers (technical depth, tools, integrations, open-source contributions, etc.)
+- Optional: coordination contact — a DevRel or community person who handles logistics day-to-day
+
+Incomplete applications won't be reviewed. Submission order is recorded but is not the only scheduling factor.
+
+## What we look for
+
+Applications are evaluated on four criteria:
+
+
+| Criteria              | What it means                                                                       |
+| --------------------- | ----------------------------------------------------------------------------------- |
+| Community relevance   | Does the topic matter to OpenClaw developers and contributors?                      |
+| Session specificity   | Is there a clear, concrete plan — not just "we'll talk about our platform"?         |
+| Speaker credibility   | Does the speaker have the expertise to deliver a strong session?                    |
+| Open-source alignment | Is the project open-source, built on open-source, or contributing to the ecosystem? |
+
+
+These are guidelines, not a scoring rubric. Each application is evaluated on its overall merit.
+
+## How decisions are made
+
+- The session coordinators (currently Jim and Andy) review applications and make scheduling decisions
+- Applications are submitted as GitHub issues; decisions are posted publicly on the same issue — accepted, declined, or deferred — with a brief explanation
+- The coordinators may consult other community members or maintainers for input on specific applications, but there is no formal committee at this stage
+- All applicants receive a response
+- Day-to-day coordination with accepted speakers happens on Discord
+
+## Scheduling
+
+Accepted sessions enter a scheduling queue. Scheduling considers:
+
+- Topic diversity (avoiding back-to-back similar sessions)
+- Speaker and community availability
+- Time-sensitive relevance (e.g., tied to a launch or release)
+- Waiting list order (earlier applicants get priority, all else being equal)
+
+## Sponsorship and contribution
+
+- Presenting at an Eco Session provides significant visibility to the OpenClaw community
+- Commercial organizations are encouraged to contribute to the OpenClaw Foundation (financial sponsorship, developer resources, or ecosystem contributions) in recognition of this value
+- Research institutions, startups in early stage, and educational organizations are exempt from sponsorship expectations
+- Sponsorship details are handled separately and do not influence the evaluation criteria above
+
+## Conflicts of interest
+
+If a coordinator has a personal, professional, or financial relationship with an applicant, they disclose it and the other coordinator takes the lead on that review.
+
+This process is open source. If you think something should change, open an issue or PR. As the sessions grow, we expect this process to evolve — adding more structure, more reviewers, and more formal oversight as needed.
+
+## Revising this process
+
+- This is v1 of the AI Ecosystem Sessions Playbook. It is intentionally lean. The goal is to be transparent about what we do and why, while retaining the flexibility to move fast and serve the community well. More structure will come as the program matures.
+


### PR DESCRIPTION
## Summary

- add `ai-ecosystem-sessions/application.md`
- document the lean v1 application and review flow for OpenClaw AI Ecosystem Sessions
- capture the current process shaped through recent session coordination work by Jim (@Protocol-zero-0) and @AndyML
- make scheduling, sponsorship expectations, and conflict-of-interest handling more transparent and reusable
